### PR TITLE
Add support for optional username and password auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Place a `config.yml` file in your working directory with the following contents:
 ```yaml
 mqtt:
   url: <your broker ip/domain>
+  username: <your broker username>
+  password: <your broker password>
 hass:
   entity_id: desktop # will be used to build the different sensors
   name: Max Desktop # will be used for the friendly name of the sensors

--- a/src/config.rs
+++ b/src/config.rs
@@ -64,6 +64,8 @@ pub struct IdleModuleConfig {
 #[derive(Debug, Clone, Deserialize)]
 pub struct MqttConfig {
     pub url: String,
+    pub username: Option<String>,
+    pub password: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,8 @@ fn main() -> anyhow::Result<()> {
 
     let mut client = Client::builder()
         .set_host(config.mqtt.url.clone())
+        .set_username(config.mqtt.username.clone())
+        .set_password(config.mqtt.password.clone().map(|s| s.as_bytes().to_vec()))
         .build()?;
 
     runtime.block_on(run(&mut client, config.clone()))?;


### PR DESCRIPTION
I added optional support to connect to the mqtt server with a username and password, as I (and a pretty decent number of other folks) run my mqtt container, history db, etc, on a separate server. If you have any feedback on the code, please do let me know as this is quite literally my first attempt at writing Rust code, so I am not familiar with any best practices or common conventions.

That said, I spun up a separate local mosquitto instance and commented out the username and password field from my config, and connected to ensure that everything still worked as before with the new additions. Evidence of this can be seen below.

<details>
<summary>Screenshot of connection and data publish with user/pass removed from config</summary>

![](https://i.imgur.com/G5SxbD8.png)

</details>

